### PR TITLE
Prefer use yarn on npm-pubish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,6 +14,6 @@ jobs:
           node-version: 12
           registry-url: https://npm.pkg.github.com/
           scope: '@password-generator'
-      - run: npm install && npm run dist && npm publish
+      - run: yarn && yarn dist && yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Prefer to use yarn on npm-publish.yml because is faster.