### PR TITLE
fix: fix commitlint github action

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -13,3 +13,4 @@ jobs:
       - uses: wagoid/commitlint-github-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          configFile:  .commitlintrc.json


### PR DESCRIPTION
In commit.yml, in this case, is necessary to pass the config file because is using .commitlintrc.json and the commitlint action search in commitlint.config.js